### PR TITLE
chore: remove pr limits as they are no longer applicable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,9 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     commit-message:
       prefix: "fix: "
     groups:
@@ -20,7 +15,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     commit-message:
       prefix: "fix: "
     groups:


### PR DESCRIPTION
Removed open-pull-requests-limit for GitHub Actions and npm dependencies.